### PR TITLE
feat: connect and leave messages

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -22,14 +22,22 @@ export class Connection {
 		socket.on('message', data => {
 			const message: Message = JSON.parse(data.toString());
 			for (const handler of this.messageHandlers) {
-				handler(this, message);
+				try {
+					handler(this, message);
+				} catch (err) {
+					console.error(err); // tslint:disable-line:no-console
+				}
 			}
 		});
 
 		socket.on('close', () => {
 			this.closed = true;
 			for (const handler of this.closeHandlers) {
-				handler();
+				try {
+					handler();
+				} catch (err) {
+					console.error(err); // tslint:disable-line:no-console
+				}
 			}
 		});
 	}

--- a/src/room.ts
+++ b/src/room.ts
@@ -1,26 +1,37 @@
 import uuid from 'uuid';
 import {Connection} from './connection';
-import {RoomStateMessage, User} from 'fluxxchat-protokolla';
+import {RoomStateMessage, User, TextMessage, Message} from 'fluxxchat-protokolla';
+import {EnabledRule, Rule} from './rules/rule';
+import {intersection} from './util';
 
 export class Room {
 	public id = uuid.v4();
 	public connections: Connection[] = [];
+	public enabledRules: EnabledRule[] = [];
 
 	public addConnection(conn: Connection) {
 		this.connections.push(conn);
 		conn.room = this;
+
+		const msg: TextMessage = {type: 'TEXT', textContent: `${conn.nickname} connected`};
+		this.broadcastMessage(msg);
+	}
+
+	public addRule(rule: Rule) {
+		this.enabledRules = this.enabledRules.filter(r => intersection(rule.ruleCategories, r.rule.ruleCategories).size === 0);
+		this.enabledRules.push(new EnabledRule(rule, null));
 	}
 
 	public removeConnection(conn: Connection) {
 		const index = this.connections.findIndex(c => c.id === conn.id);
 		this.connections.splice(index, 1);
+
+		const msg: TextMessage = {type: 'TEXT', textContent: `${conn.nickname} disconnected`};
+		this.broadcastMessage(msg);
 	}
 
 	public sendStateMessages() {
-		const state = this.getStateMessage();
-		for (const conn of this.connections) {
-			conn.sendMessage(state);
-		}
+		this.broadcastMessage(this.getStateMessage());
 	}
 
 	public getStateMessage(): RoomStateMessage {
@@ -29,5 +40,11 @@ export class Room {
 			type: 'ROOM_STATE',
 			users
 		};
+	}
+
+	public broadcastMessage(msg: Message) {
+		for (const conn of this.connections) {
+			conn.sendMessage(msg);
+		}
 	}
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,66 +1,41 @@
 import {Message, RoomCreatedMessage} from 'fluxxchat-protokolla';
-import {EnabledRule} from './rules/rule';
 import {Connection} from './connection';
 import {Room} from './room';
-import {intersection} from './util';
 import {RULES} from './rules/active-rules';
 
 export class FluxxChatServer {
-	private enabledRules: EnabledRule[] = [];
 	private connections: Connection[] = [];
-	private rooms: { [id: string]: Room} = {};
+	private rooms: {[id: string]: Room} = {};
 
 	public handleMessage(conn: Connection, message: Message) {
-		if (!conn.room) {
-			if (message.type === 'JOIN_ROOM') {
-				conn.nickname = message.nickname;
-				if (this.rooms[message.roomId]) {
-					const room = this.rooms[message.roomId];
-					room.addConnection(conn);
-					room.sendStateMessages();
-				} else {
-					console.log('Unknown room: ' + message.roomId); // tslint:disable-line:no-console
-					return;
+		switch (message.type) {
+			case 'JOIN_ROOM':
+				return this.joinRoom(conn, message.roomId, message.nickname);
+			case 'CREATE_ROOM':
+				return this.createRoom(conn);
+			case 'LEAVE_ROOM':
+				return this.removeConnection(conn);
+			default:
+				if (!conn.room) {
+					throw new Error('Must be connected to a room');
 				}
-			} else if (message.type === 'CREATE_ROOM') {
-				const room = new Room();
-				this.rooms[room.id] = room;
-				conn.sendMessage({type: 'ROOM_CREATED', roomId: room.id} as RoomCreatedMessage);
-				return;
-			} else {
-				console.log('Illegal message type in roomless state: ' + message.type); // tslint:disable-line:no-console
-				return;
-			}
-			return;
+				break;
 		}
 
-		// special code for the new rule message
 		if (message.type === 'NEW_RULE') {
-			if (RULES[message.ruleName]) {
-				const newRule = RULES[message.ruleName];
-				this.enabledRules = this.enabledRules.filter(r => intersection(newRule.ruleCategories, r.rule.ruleCategories).size === 0);
-				this.enabledRules.push(new EnabledRule(newRule, null));
-			} else {
-				console.log('Unknown rule: ' + message.ruleName); // tslint:disable-line:no-console
-				return;
-			}
+			this.enactRule(conn, message.ruleName);
 		}
 
 		if (message.type === 'TEXT') {
 			message.senderNickname = conn.nickname;
 		}
 
-		// main routine
-		for (const rule of this.enabledRules) {
+		for (const rule of conn.room.enabledRules) {
 			message = rule.applyMessage(this, message);
 		}
 
 		for (const connection of conn.room.connections) {
-			try {
-				connection.sendMessage(message);
-			} catch (err) {
-				console.error(`Could not send message to client: ${err.message}`); // tslint:disable-line:no-console
-			}
+			connection.sendMessage(message);
 		}
 
 		// remove closed connections
@@ -80,5 +55,45 @@ export class FluxxChatServer {
 		this.connections.push(conn);
 		conn.onMessage((_, message) => this.handleMessage(conn, message));
 		conn.onClose(() => this.removeConnection(conn));
+	}
+
+	private enactRule(conn: Connection, ruleName: string) {
+		if (!conn.room) {
+			throw new Error('Must be connected to a room');
+		}
+
+		const rule = RULES[ruleName];
+		if (!rule) {
+			throw new Error(`No such rule: ${ruleName}`);
+		}
+
+		conn.room.addRule(rule);
+	}
+
+	private createRoom(conn: Connection) {
+		const room = new Room();
+		this.rooms[room.id] = room;
+		conn.sendMessage({type: 'ROOM_CREATED', roomId: room.id} as RoomCreatedMessage);
+	}
+
+	private joinRoom(conn: Connection, roomId: string, requestedNickname: string) {
+		const room = this.rooms[roomId];
+
+		if (room) {
+			if (room.connections.find(c => c.nickname === requestedNickname)) {
+				// Someone else already has the requested nickname in this room
+				throw new Error(`Nickname taken: ${requestedNickname}`);
+			}
+
+			if (conn.room) {
+				conn.room.removeConnection(conn);
+			}
+
+			conn.nickname = requestedNickname;
+			room.addConnection(conn);
+			room.sendStateMessages();
+		} else {
+			throw new Error(`Room does not exist: ${roomId}`);
+		}
 	}
 }


### PR DESCRIPTION
- Handle `LEAVE_ROOM` messages
- General refactoring
- When user leaves room, broadcast a `<nickname> disconnected` message to other users
- When user join room, broadcast a `<nickname> connected` message to all users (including the user who joined)