### PR TITLE
feat: player turns

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -62,6 +62,10 @@ export class FluxxChatServer {
 			throw new Error('Must be connected to a room');
 		}
 
+		if (!conn.room.turn || conn.room.turn.id !== conn.id) {
+			throw new Error('You can only play cards on your turn');
+		}
+
 		const rule = RULES[ruleName];
 		if (!rule) {
 			throw new Error(`No such rule: ${ruleName}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,7 +925,7 @@ findup-sync@0.4.2:
 
 "fluxxchat-protokolla@git://github.com/FluxxChat/FluxxChat-protokolla.git":
   version "1.0.0"
-  resolved "git://github.com/FluxxChat/FluxxChat-protokolla.git#05ad965d04b5a80596703130dedf099d1d21f5b0"
+  resolved "git://github.com/FluxxChat/FluxxChat-protokolla.git#776b19d4c2f9f2cd62054cc1f24c51408cd1974e"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
- When a player joins a room, push him to the front of the list of players. This way, when the turn goes to the next player, new players get their turn after existing players.
- When a player joins an empty room, give the turn to him.
- When a player leaves a room, the turn goes to the next player.
- When player plays a card, give the turn to the next player.
- If a player tries to play a card, make sure it's his/her turn.