### PR TITLE
feat: event log endpoint with auth

### DIFF
--- a/src/lib/auth-middleware.ts
+++ b/src/lib/auth-middleware.ts
@@ -1,0 +1,15 @@
+export function basicAuth(users: Map<string, string>) {
+	return (req, res, next) => {
+		const b64auth = (req.headers.authorization || '').split(' ')[1] || '';
+		const [login, password] = new Buffer(b64auth, 'base64').toString().split(':');
+
+		const validLogin = users.has(login) && users.get(login) === password;
+
+		if (!validLogin) {
+			res.set('WWW-Authenticate', 'Basic realm="401"');
+			res.status(401).send('Authentication required');
+			return;
+		}
+		next();
+	};
+}


### PR DESCRIPTION
Adds http endpoint for accessing event logs. Http basic auth is in place. Actual login information is configured in environment variables (I added config vars to heroku). When developing locally, you can use the user `admin:admin`.

Endpoint is located at `/events`